### PR TITLE
Resolve license warning during pod install

### DIFF
--- a/SJSONDecoder.podspec
+++ b/SJSONDecoder.podspec
@@ -36,7 +36,7 @@ Pod::Spec.new do |spec|
   #  Popular ones are 'MIT', 'BSD' and 'Apache License, Version 2.0'.
   #
 
-  spec.license      = { :type => 'MIT', :file => 'LICENSE.md' }
+  spec.license      = { :type => 'MIT', :file => 'LICENSE' }
 
 
   # ――― Author Metadata  ――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #


### PR DESCRIPTION
At the moment, cocoapods gives a warning
```
[!] Unable to read the license file `LICENSE.md` for the spec `SJSONDecoder (0.0.5)`
```

this happens because the file is currently named `LICENSE` and not `LICENSE.md`. So I corrected this in the podspec.

P.S. AFAIK the issue is still not fixed in the Swift builtin parser. If you aware of any other way to fix the parsing of decimal numbers, please let me know :) 